### PR TITLE
respect @disabled flag pchtxt

### DIFF
--- a/libultra/source/mod_funcs.cpp
+++ b/libultra/source/mod_funcs.cpp
@@ -283,6 +283,7 @@ namespace ult {
         }
     
         int offset = 0;
+        bool enabled = true;
         StringStream iss(pchtxt);  // Use your custom StringStream
         std::string line;
         
@@ -300,11 +301,21 @@ namespace ult {
             }
     
             if (line.find("@enabled") == 0) {
+                enabled = true;
+                continue;
+            }
+
+            if (line.find("@disabled") == 0) {
+                enabled = false;
                 continue;
             }
     
             if (line.find("@stop") == 0) {
                 break;
+            }
+
+            if (!enabled) {
+                continue;
             }
     
             size_t spacePos = line.find(' ');
@@ -418,6 +429,7 @@ namespace ult {
         uint32_t lineNum = 0;
         std::string nsobid;
         int offset = 0; // Default offset
+        bool enabled = true;
     
         uint32_t address;
         uint8_t byte;
@@ -425,13 +437,21 @@ namespace ult {
     
         while (fgets(&line[0], line.size(), pchtxtFile) != nullptr) {
             ++lineNum;
-            if (line.empty() || line.front() == '@') {
+            if (line.empty() || line.front() == '@' || !enabled) {
                 if (line.find("@nsobid-") == 0) {
                     nsobid = line.substr(8);
                 }
                 if (line.find("@flag offset_shift ") == 0) {
                     std::string offsetStr = line.substr(19);
                     offset = (offsetStr.find("0x") == 0 ? std::strtol(offsetStr.c_str(), nullptr, 16) : std::strtol(offsetStr.c_str(), nullptr, 10));
+                }
+                if (line.find("@enabled") == 0) {
+                    enabled = true;
+                    continue;
+                }
+                if (line.find("@disabled") == 0) {
+                    enabled = false;
+                    continue;
                 }
                 if (line.find("@stop") == 0) {
                     break;
@@ -487,6 +507,7 @@ namespace ult {
         uint32_t lineNum = 0;
         std::string nsobid;
         int offset = 0; // Default offset
+        bool enabled = true;
     
         uint32_t address;
         uint8_t byte;
@@ -494,7 +515,7 @@ namespace ult {
     
         while (std::getline(pchtxtFile, line)) {
             ++lineNum;
-            if (line.empty() || line.front() == '@') {
+            if (line.empty() || line.front() == '@' || !enabled) {
                 if (line.find("@nsobid-") == 0) {
                     nsobid = line.substr(8);
                 }
@@ -504,6 +525,14 @@ namespace ult {
                 }
                 if (line.find("@stop") == 0) {
                     break;
+                }
+                if (line.find("@enabled") == 0) {
+                    enabled = true;
+                    continue;
+                }
+                if (line.find("@disabled") == 0) {
+                    enabled = false;
+                    continue;
                 }
                 continue;  // Skip empty lines and lines starting with '@'
             }


### PR DESCRIPTION
Pchtxt files can have multiple patches in a single .pchtxt file, separated by `@enabled` or `@disabled.` This prevents the converters from outputting patch lines that are supposed to be disabled.