### PR TITLE
Modification of Chinese Font Loading Logic

### DIFF
--- a/libtesla/include/tesla.hpp
+++ b/libtesla/include/tesla.hpp
@@ -3846,14 +3846,12 @@ namespace tsl {
                     switch (setLanguage) {
                     case SetLanguage_ZHCN:
                     case SetLanguage_ZHHANS:
+                    case SetLanguage_ZHTW:
+                    case SetLanguage_ZHHANT:
                         TSL_R_TRY(plGetSharedFontByType(&localFontData, PlSharedFontType_ChineseSimplified));
                         break;
                     case SetLanguage_KO:
                         TSL_R_TRY(plGetSharedFontByType(&localFontData, PlSharedFontType_KO));
-                        break;
-                    case SetLanguage_ZHTW:
-                    case SetLanguage_ZHHANT:
-                        TSL_R_TRY(plGetSharedFontByType(&localFontData, PlSharedFontType_ChineseTraditional));
                         break;
                     default:
                         this->m_hasLocalFont = false;


### PR DESCRIPTION
I have noticed that libultrahand currently selects and loads simplified or traditional Chinese fonts based on the system language. However, in practical scenarios, loading simplified Chinese fonts is almost always the more optimal choice.

In the system-shared font library, ChineseSimplified.ttf contains nearly all the glyphs from ChineseTraditional.ttf (13,954 out of 14,945). Of the remaining 991 glyphs, half are blank, and the other half are completely meaningless.

The current issue is that simplified characters fail to display when the system language is set to traditional Chinese. This problem can be avoided by uniformly loading PlSharedFontType_ChineseSimplified. Meanwhile, this has no side effects.


Before：<img src="https://github.com/user-attachments/assets/2a830a54-c702-4c81-beb2-8c2726057897" alt="Before" width="200"> After： <img src="https://github.com/user-attachments/assets/7be25f37-4a75-4677-b05e-4788b6d80d27" alt="After" width="200">

[PlSharedFontType_ChineseSimplified.zip](https://github.com/user-attachments/files/23479434/PlSharedFontType_ChineseSimplified.zip)
[PlSharedFontType_ChineseTraditional.zip](https://github.com/user-attachments/files/23479437/PlSharedFontType_ChineseTraditional.zip)
[diff.txt](https://github.com/user-attachments/files/23479438/diff.txt)
