### PR TITLE
Add configurable hold duration and fix click-animation guard on ToggleListItem

### DIFF
--- a/libtesla/include/tesla.hpp
+++ b/libtesla/include/tesla.hpp
@@ -8062,7 +8062,8 @@ namespace tsl {
                         this->setState(this->m_state);
                     
                     this->m_stateChangedListener(this->m_state);
-                    this->triggerClickAnimation();
+                    if (m_flags.m_useClickAnimation)
+                        this->triggerClickAnimation();
                     
                     return Element::onClick(keys);
                 }

--- a/libultra/include/tsl_utils.hpp
+++ b/libultra/include/tsl_utils.hpp
@@ -158,6 +158,8 @@ namespace ult {
     extern std::atomic<bool> runningInterpreter;
     extern std::atomic<bool> shakingProgress;
     
+    extern u32 holdDurationMs;
+    
     extern std::atomic<bool> isHidden;
     extern std::atomic<bool> externalAbortCommands;
     
@@ -312,6 +314,9 @@ namespace ult {
     extern std::string FAVORITE;
     extern std::string MAIN_SETTINGS;
     extern std::string UI_SETTINGS;
+
+    extern std::string INPUT;
+    extern std::string HOLD_TIME;
 
     extern std::string WIDGET;
     extern std::string WIDGET_ITEMS;

--- a/libultra/source/tsl_utils.cpp
+++ b/libultra/source/tsl_utils.cpp
@@ -255,7 +255,9 @@ namespace ult {
     std::atomic<bool> threadFailure(false);
     std::atomic<bool> runningInterpreter(false);
     std::atomic<bool> shakingProgress(true);
-    
+
+    u32 holdDurationMs = 3000;
+
     std::atomic<bool> isHidden(false);
     std::atomic<bool> externalAbortCommands(false);
     
@@ -403,6 +405,8 @@ namespace ult {
     std::string FAVORITE;
     std::string MAIN_SETTINGS;
     std::string UI_SETTINGS;
+    std::string INPUT;
+    std::string HOLD_TIME;
     std::string WIDGET;
     std::string WIDGET_ITEMS;
     std::string WIDGET_SETTINGS;
@@ -617,6 +621,8 @@ namespace ult {
         {&FAVORITE,                   "FAVORITE",                   "Favorite"},
         {&MAIN_SETTINGS,              "MAIN_SETTINGS",              "Main Settings"},
         {&UI_SETTINGS,                "UI_SETTINGS",                "UI Settings"},
+        {&INPUT,                      "INPUT",                      "Input"},
+        {&HOLD_TIME,                  "HOLD_TIME",                  "Hold Time"},
         {&WIDGET,                     "WIDGET",                     "Widget"},
         {&WIDGET_ITEMS,               "WIDGET_ITEMS",               "Widget Items"},
         {&WIDGET_SETTINGS,            "WIDGET_SETTINGS",            "Widget Settings"},


### PR DESCRIPTION
# Add configurable hold duration and fix click-animation guard on ToggleListItem

## Summary

Two small additions to libultrahand needed by the upcoming `Ultrahand-Overlay` PR for a configurable per-user hold duration on toggle items and system actions.

### `dd7c386` — Add configurable hold duration strings and variables

Adds the symbol that the overlay reads/writes when the user changes the hold duration in Settings → Input.

- `libultra/include/tsl_utils.hpp`:
  - `extern u32 holdDurationMs;`
  - `extern std::string INPUT;` and `extern std::string HOLD_TIME;` (translation handles for the new settings entries).
- `libultra/source/tsl_utils.cpp`:
  - `u32 holdDurationMs = 3000;` (current behavior preserved as the default).
  - English defaults `INPUT="Input"` and `HOLD_TIME="Hold Time"` plus their entries in the translation table.

The overlay reads `holdDurationMs` from `ULTRAHAND_CONFIG_INI_PATH`, clamps it to `[500, 10000]`, and writes back via the new trackbar. Default of `3000` matches the previously hard-coded value, so behavior for users who never touch the setting is unchanged.

### `8fdea36` — Fix hold progress bar not rendering on `ToggleListItem` with disabled click animation

When `disableClickAnimation()` is called on a toggle item, `m_flags.m_useClickAnimation` is set to `false`. The existing `onClick` path then unconditionally called `triggerClickAnimation()`, which forced the hold-progress UI to draw the click animation overlay anyway — making the hold progress bar invisible/wrong on toggles that opted out of the click animation.

Wraps the call in the existing flag check that the rest of the file already uses:

```cpp
if (m_flags.m_useClickAnimation)
    this->triggerClickAnimation();
```

No new fields, no new flags — just the missing guard.

## Why this is a separate PR from `Ultrahand-Overlay`

`Ultrahand-Overlay` references libultrahand as a submodule. The companion PR there exposes the new settings UI and reads `ult::holdDurationMs`. That PR cannot be merged before these two libultrahand commits land — without `holdDurationMs` the overlay won't compile.

Companion: https://github.com/ppkantorski/Ultrahand-Overlay/pull/309

## Verification

- The two changes touch only the listed files; no other source is altered.
- `m_flags.m_useClickAnimation` already exists in `tesla.hpp` and is used elsewhere in the same file — no new state to maintain.
- `holdDurationMs` default of `3000` matches the previously hard-coded value, so consumers that don't read the new symbol continue to behave as before.

## Test plan

- Build `Ultrahand-Overlay` against this branch and verify the existing toggle/hold flows behave identically with the default 3 s setting.
- Set the new "Hold Time" trackbar in Settings → Input to 0.5 s and 5.0 s, restart the overlay, and confirm hold-to-launch on toggle items and system actions tracks the chosen duration.
- On a toggle item that calls `disableClickAnimation()`, hold-launch and confirm the hold-progress bar renders cleanly (this is the bug `8fdea36` fixes).

## Notes

- Branch is rebased on top of current `main` (`9b886230`); both commits apply cleanly with no conflicts against the three intermediate `main` commits (temperature defaults in `libtesla/include/tesla.hpp` + `README.md`).
- The companion `Ultrahand-Overlay` PR also includes a separate fix in its `processHold` cancel path that only became visible once the libultrahand `setState` guard was dropped; that change is in the overlay, not here.
